### PR TITLE
Universal Renderer

### DIFF
--- a/src/main/java/org/dynmap/blockscan/DynmapBlockScanPlugin.java
+++ b/src/main/java/org/dynmap/blockscan/DynmapBlockScanPlugin.java
@@ -476,21 +476,26 @@ public class DynmapBlockScanPlugin
 
             BlockStateContainer blockStateContainer = block.getBlockState();
             for (IBlockState blockState : blockStateContainer.getValidStates()) {
-                int stateMeta = block.getMetaFromState(blockState);
+                try {
+                    int stateMeta = block.getMetaFromState(blockState);
 
-                int[] meta = new int[]{stateMeta};
+                    int[] meta = new int[]{stateMeta};
 
-                PatchBlockModel blockModelRecord = modRecord.getPatchModelRec(blockName, meta);
-                BlockTextureRecord blockTextureRecord = modRecord.getBlockTxtRec(blockName, meta);
+                    PatchBlockModel blockModelRecord = modRecord.getPatchModelRec(blockName, meta);
+                    BlockTextureRecord blockTextureRecord = modRecord.getBlockTxtRec(blockName, meta);
 
-                IBakedModel model = blockRendererDispatcher.getModelForState(blockState);
+                    IBakedModel model = blockRendererDispatcher.getModelForState(blockState);
 
-                int[] patchIndex = new int[]{0};
+                    int[] patchIndex = new int[]{0};
 
-                quads(model, blockState, null, modRecord, blockModelRecord, blockTextureRecord, patchIndex);
+                    quads(model, blockState, null, modRecord, blockModelRecord, blockTextureRecord, patchIndex);
 
-                for (EnumFacing facing : EnumFacing.values()) {
-                    quads(model, blockState, facing, modRecord, blockModelRecord, blockTextureRecord, patchIndex);
+                    for (EnumFacing facing : EnumFacing.values()) {
+                        quads(model, blockState, facing, modRecord, blockModelRecord, blockTextureRecord, patchIndex);
+                    }
+                } catch (Exception exception) {
+                    RuntimeException blockStateError = new RuntimeException("Error while extracting model for BlockState " + blockState.toString(), exception);
+                    blockStateError.printStackTrace();
                 }
             }
         }

--- a/src/main/java/org/dynmap/blockscan/DynmapBlockScanPlugin.java
+++ b/src/main/java/org/dynmap/blockscan/DynmapBlockScanPlugin.java
@@ -461,6 +461,8 @@ public class DynmapBlockScanPlugin
         }
     }
 
+    private List<String> previouslyLoaded = new ArrayList<>();
+
     private void extractModelsFromRendererDispatcher() {
         BlockRendererDispatcher blockRendererDispatcher = Minecraft.getMinecraft().getBlockRendererDispatcher();
 
@@ -478,6 +480,10 @@ public class DynmapBlockScanPlugin
             for (IBlockState blockState : blockStateContainer.getValidStates()) {
                 try {
                     int stateMeta = block.getMetaFromState(blockState);
+
+                    String loadedName = modId + ":" + blockName + ":" + stateMeta;
+                    if (previouslyLoaded.contains(loadedName)) continue;
+                    previouslyLoaded.add(loadedName);
 
                     int[] meta = new int[]{stateMeta};
 
@@ -693,6 +699,9 @@ public class DynmapBlockScanPlugin
         	BlockRecord br = blockRecords.get(blkname);
         	if (br.sc != null) {
         		for (Entry<StateRec, List<VariantList>> var : br.varList.entrySet()) {
+                    String loadedName = blkname + ":" + var.getKey().metadata[0];
+                    if (previouslyLoaded.contains(loadedName)) continue;
+
         		    // Produce merged element lists : for now, ignore random weights and just use first element of each section
         		    List<BlockElement> elems = new ArrayList<BlockElement>();
                     for (VariantList vl : var.getValue()) {


### PR DESCRIPTION
Hello!
I recently experimented with dynmap for minecraft forge and wanted it to render the models of all installed mods.
I hat limited success with DynmapBlockScan because many mods don't have resource files that can be used to extract their model and texture information.
Because of this limitation I tried to extract the model information from the BakedModels directly.

It works pretty well allthough it has its own limitations.
Below are two screenshots to better demonstrate the functionality. In these screenshots I generated all models (including all minecraft models) directly from their BakedModels.
![dynmap-renderer](https://user-images.githubusercontent.com/1524059/61566653-46626c00-aa7d-11e9-9e2e-18be875299c4.png)

The original world looked like this:
![dynmap-renderer-original](https://user-images.githubusercontent.com/1524059/61566720-54b08800-aa7d-11e9-8d24-8737a0d5fb38.png)

As you can see there are some problems rendering the top of grass, stairs and some other blocks that cannot be differentiated only by their metadata and that would need their own renderer. Maybe a feature where the full blockstate can be specified in the model files could overcome this. Also water seems to render invisible. But for the most part this renderer gets many models right. It exports all the possible blockstates for stairs for example but because they are all linked to the same metadata, dynmap only picks the last one. Also I don't know where these black spots are coming from. Maybe the renderer thinks that the block next to it is a full cube?
I was suprised to see that even levers, pistons and other non-cube models render fine.

I just wanted to share my experiments with you all because this method could drastically improve mod compatibility.

Here is a screenshot showing a few blocks from chisel and a few others:
![image](https://user-images.githubusercontent.com/1524059/61568504-de635400-aa83-11e9-8fa9-38d84abcdd35.png)
