### PR TITLE
Add support for minecraft 1.16.4

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,13 +3,13 @@ buildscript {
     repositories {
      mavenLocal()
      maven { url "https://oss.sonatype.org/content/repositories/releases" }
-     maven { url "http://repo.mikeprimm.com" }
+     maven { url "https://repo.mikeprimm.com" }
      maven { url "https://repo.maven.apache.org/maven2" }
      maven { url "https://hub.spigotmc.org/nexus/content/repositories/snapshots/" }
      maven { url "https://repo.codemc.org/repository/maven-public/" }
-     maven { url = 'https://files.minecraftforge.net/maven' }
+     maven { url "https://files.minecraftforge.net/maven" }
      jcenter()
-     mavenCentral()     
+     mavenCentral()
     }
     dependencies {
         classpath group: 'net.minecraftforge.gradle', name: 'ForgeGradle', version: '3.+', changing: true
@@ -37,7 +37,7 @@ ext.buildNumber = System.getenv().BUILD_NUMBER ?: "Dev"
 
 dependencies {
     compile group: 'us.dynmap', name: 'DynmapCoreAPI', version: "${config.Dynmap_version}${config.DynmapCore_devversion}", ext: 'jar'
-    minecraft 'net.minecraftforge:forge:1.15.2-31.2.9'
+    minecraft 'net.minecraftforge:forge:1.16.4-35.1.4'
 }
 
 minecraft {
@@ -51,6 +51,7 @@ minecraft {
 
 repositories {
     mavenLocal()
+    maven { url "https://repo.mikeprimm.com" }
 }
 
 configurations {
@@ -61,18 +62,18 @@ configurations {
 processResources
 {
     inputs.property "version", project.version + '-' + project.ext.buildNumber
-    
+
     // replace stuff in mcmod.info, nothing else
     from(sourceSets.main.resources.srcDirs) {
         include 'META-INF/mods.toml'
-                
+
         // replace version and mcversion
         expand(
         	version: project.version + '-' + project.ext.buildNumber,
-        	mcversion: "1.15.2"
+        	mcversion: "1.16.4"
     	)
     }
-        
+
     // copy everything else, thats not the mcmod.info
     from(sourceSets.main.resources.srcDirs) {
         exclude 'META-INF/mods.toml'

--- a/build.properties
+++ b/build.properties
@@ -1,6 +1,6 @@
-minecraft_version=1.15.2
-forge_version=31.2.9
+minecraft_version=1.16.4
+forge_version=35.1.4
 Dynmap_version=3.0
 Dynmap_extversion=-SNAPSHOT
 DynmapCore_devversion=-SNAPSHOT
-mapping_version=20200514-1.15.1
+mapping_version=20201228-1.16.4

--- a/src/main/java/org/dynmap/blockscan/DynmapBlockScanPlugin.java
+++ b/src/main/java/org/dynmap/blockscan/DynmapBlockScanPlugin.java
@@ -73,7 +73,6 @@ import org.dynmap.blockscan.statehandlers.GateMetadataStateHandler;
 
 import net.minecraft.block.Block;
 import net.minecraft.server.MinecraftServer;
-import net.minecraft.state.IProperty;
 import net.minecraft.util.Direction;
 import net.minecraft.util.IStringSerializable;
 import net.minecraft.util.ObjectIntIdentityMap;
@@ -88,17 +87,17 @@ public class DynmapBlockScanPlugin
 {
     public static OurLog logger = new OurLog();
     public static DynmapBlockScanPlugin plugin;
-    
+
     private Map<Direction, BlockSide> faceToSide = new HashMap<Direction, BlockSide>();
     private BlockStateOverrides overrides;
-    
+
     public static class BlockRecord {
     	public StateContainer sc;
     	public Map<StateRec, List<VariantList>> varList;	// Model references for block
     	public Set<String> renderProps;	// Set of render properties
     	public IStateHandler handler;		// Best handler
     }
-    
+
     private IStateHandlerFactory[] state_handler = {
         new NSEWConnectedMetadataStateHandler(),
         new NSEWUConnectedMetadataStateHandler(),
@@ -116,7 +115,7 @@ public class DynmapBlockScanPlugin
     public DynmapBlockScanPlugin(MinecraftServer srv)
     {
         plugin = this;
-        
+
         faceToSide.put(Direction.DOWN, BlockSide.FACE_0);
         faceToSide.put(Direction.UP, BlockSide.FACE_1);
         faceToSide.put(Direction.NORTH, BlockSide.FACE_2);
@@ -140,10 +139,10 @@ public class DynmapBlockScanPlugin
     	PathDirectory(String mid) {
     		super(mid);
     	}
-    	
+
     }
     private static Map<String, PathElement> assetmap;	// Map of asset paths and mods containing them
-    
+
     private void addElement(String modid, String n) {
     	String[] tok = n.split("/");
     	PathElement pe;
@@ -199,7 +198,7 @@ public class DynmapBlockScanPlugin
     	}
     	return m.get(tok[tok.length - 1]);
     }
-    
+
     private static String scanForElement(Map<String, PathElement> m, String base, String fname) {
     	for (Entry<String, PathElement> me : m.entrySet()) {
     		PathElement p = me.getValue();
@@ -214,7 +213,7 @@ public class DynmapBlockScanPlugin
     	}
     	return null;
     }
-    
+
     public void buildAssetMap() {
     	assetmap = new HashMap<String, PathElement>();
         List<ModInfo> mcl = ModList.get().getMods();
@@ -255,7 +254,7 @@ public class DynmapBlockScanPlugin
         	}
         }
     }
-    
+
     public void onEnable() {
     }
     public void onDisable() {
@@ -314,7 +313,7 @@ public class DynmapBlockScanPlugin
 
         // Now process models from block records
         Map<String, BlockModel> models = new HashMap<String, BlockModel>();
-        
+
         ObjectIntIdentityMap<net.minecraft.block.BlockState> bsids = Block.BLOCK_STATE_IDS;
         Block baseb = null;
         Iterator<net.minecraft.block.BlockState> iter = bsids.iterator();
@@ -401,7 +400,7 @@ public class DynmapBlockScanPlugin
             }
             blockRecords.put(rl.toString(), br);
         }
-        
+
         logger.info("Loading models....");
         for (String blkname : blockRecords.keySet()) {
         	BlockRecord br = blockRecords.get(blkname);
@@ -489,20 +488,20 @@ public class DynmapBlockScanPlugin
         	}
         }
         logger.info("Elements generated");
-        
+
         publishDynmapModData();
-        
+
         assetmap = null;
     }
-    
+
     private ModSupportAPI dynmap_api;
-    
+
     private static class ModDynmapRec {
     	ModTextureDefinition txtDef;
     	ModModelDefinition modDef;
     	Map<String, TextureFile> textureIDsByPath = new HashMap<String, TextureFile>();
     	int nextTxtID = 1;
-    	
+
     	public TextureFile registerTexture(String txtpath) {
     	    txtpath = txtpath.toLowerCase();
     		TextureFile txtf = textureIDsByPath.get(txtpath);
@@ -578,7 +577,7 @@ public class DynmapBlockScanPlugin
         }
     }
     private Map<String, ModDynmapRec> modTextureDef = new HashMap<String, ModDynmapRec>();
-    
+
     private ModDynmapRec getModRec(String modid) {
         if (dynmap_api == null) {
             dynmap_api = ModSupportAPI.getAPI();
@@ -621,7 +620,7 @@ public class DynmapBlockScanPlugin
         }
         return meta;
     }
-        
+
     public void registerSimpleDynmapCubes(String blkname, StateRec state, BlockElement element, WellKnownBlockClasses type) {
     	String[] tok = blkname.split(":");
     	String modid = tok[0];
@@ -631,7 +630,7 @@ public class DynmapBlockScanPlugin
     		return;
     	}
         // Temporary hack to avoid registering metadata duplicates
-    	meta = pruneDuplicateMeta(blkname, meta); 
+    	meta = pruneDuplicateMeta(blkname, meta);
     	if (meta.length == 0) {
             return;
         }
@@ -673,7 +672,7 @@ public class DynmapBlockScanPlugin
                 btr.setBlockColorMapTexture(gtf);
             }
         }
-       
+
     	// Loop over the images for the element
     	for (Entry<Direction, BlockFace> face : element.faces.entrySet()) {
     	    Direction facing = face.getKey();
@@ -710,7 +709,7 @@ public class DynmapBlockScanPlugin
         }
         return true;
     }
-    
+
     public void registerSimpleDynmapCuboids(String blkname, StateRec state, List<BlockElement> elems, WellKnownBlockClasses type) {
         String[] tok = blkname.split(":");
         String modid = tok[0];
@@ -720,7 +719,7 @@ public class DynmapBlockScanPlugin
             return;
         }
         // Temporary hack to avoid registering metadata duplicates
-        meta = pruneDuplicateMeta(blkname, meta); 
+        meta = pruneDuplicateMeta(blkname, meta);
         if (meta.length == 0) {
             return;
         }
@@ -824,7 +823,7 @@ public class DynmapBlockScanPlugin
             return;
         }
         // Temporary hack to avoid registering metadata duplicates
-        meta = pruneDuplicateMeta(blkname, meta); 
+        meta = pruneDuplicateMeta(blkname, meta);
         if (meta.length == 0) {
             return;
         }
@@ -920,7 +919,7 @@ public class DynmapBlockScanPlugin
             }
         }
     }
-    
+
     private String addPatch(PatchBlockModel mod, Direction facing, BlockElement be) {
         // First, do the rotation on the from/to
         Vector3D fromvec = new Vector3D(be.from[0], be.from[1], be.from[2]);
@@ -1012,7 +1011,7 @@ public class DynmapBlockScanPlugin
         return mod.addPatch(originvec.x, originvec.y, originvec.z, uvec.x, uvec.y, uvec.z, vvec.x, vvec.y, vvec.z, SideVisible.TOP);
     }
 
-    
+
     public void publishDynmapModData() {
     	for (ModDynmapRec mod : modTextureDef.values()) {
     		if (mod.txtDef != null) {
@@ -1024,9 +1023,9 @@ public class DynmapBlockScanPlugin
                 logger.info("Published " + mod.modDef.getModID() + " models to Dynmap");
             }
     	}
-    
+
     }
-    
+
     public static InputStream openAssetResource(String modid, String subpath, String resourcepath, boolean scan) {
     	String pth = "assets/" + modid + "/" + subpath + "/" + resourcepath;
     	PathElement pe = findElement(assetmap, pth);
@@ -1075,11 +1074,11 @@ public class DynmapBlockScanPlugin
         }
         return null;
     }
-    
+§
     public Map<String, List<String>> buildPropoertMap(net.minecraft.state.StateContainer<Block, net.minecraft.block.BlockState> bsc) {
     	Map<String, List<String>> renderProperties = new HashMap<String, List<String>>();
 		// Build table of render properties and valid values
-		for (IProperty<?> p : bsc.getProperties()) {
+		for (net.minecraft.state.Property<?> p : bsc.getProperties()) {
 			String pn = p.getName();
 			ArrayList<String> pvals = new ArrayList<String>();
 			for (Comparable<?> val : p.getAllowedValues()) {
@@ -1094,11 +1093,12 @@ public class DynmapBlockScanPlugin
 		}
 		return renderProperties;
     }
-    
+
     // Build ImmutableMap<String, String> from properties in BlockState
     public ImmutableMap<String, String> fromBlockState(net.minecraft.block.BlockState bs) {
     	ImmutableMap.Builder<String,String> bld = ImmutableMap.builder();
-    	for (IProperty<?> x : bs.getProperties()) {
+      // func_235904_r_ == getProperties
+    	for (net.minecraft.state.Property<?> x : bs.func_235904_r_()) {
     	    Object v = bs.get(x);
     		if (v instanceof IStringSerializable) {
     			bld.put(x.getName(), ((IStringSerializable)v).getName());
@@ -1109,10 +1109,10 @@ public class DynmapBlockScanPlugin
     	}
     	return bld.build();
     }
-    
+
     private static BlockState loadBlockState(String modid, String respath, BlockStateOverrides override, Map<String, List<String>> propMap) {
     	BlockStateOverride ovr = override.getOverride(modid, respath);
-    	
+
     	if (ovr == null) {	// No override
     		return loadBlockStateFile(modid, respath);
     	}
@@ -1139,14 +1139,14 @@ public class DynmapBlockScanPlugin
 
 		return null;
     }
-    
+
     private static BlockState loadBlockStateFile(String modid, String respath) {
     	// Default path
         String path = "assets/" + modid + "/blockstates/" + respath + ".json";
     	BlockState bs = null;
         InputStream is = openAssetResource(modid, "blockstates", respath + ".json", true);
         if (is == null) {	// Not found? scan for name under blockstates directory (some mods do this...)
-        	
+
         }
         if (is != null) {	// Found it?
         	Reader rdr = new InputStreamReader(is, Charsets.UTF_8);
@@ -1171,7 +1171,7 @@ public class DynmapBlockScanPlugin
         }
         return bs;
     }
-    
+
     private static BlockModel loadBlockModelFile(String modid, String respath) {
         String path = "assets/" + modid + "/models/" + respath + ".json";
     	BlockModel bs = null;
@@ -1201,7 +1201,7 @@ public class DynmapBlockScanPlugin
         }
         return bs;
     }
-    
+
     public static class OurLog {
         Logger log;
         public static final String DM = "";
@@ -1234,4 +1234,3 @@ public class DynmapBlockScanPlugin
         }
     }
 }
-

--- a/src/main/java/org/dynmap/blockscan/DynmapBlockScanPlugin.java
+++ b/src/main/java/org/dynmap/blockscan/DynmapBlockScanPlugin.java
@@ -1074,7 +1074,7 @@ public class DynmapBlockScanPlugin
         }
         return null;
     }
-§
+
     public Map<String, List<String>> buildPropoertMap(net.minecraft.state.StateContainer<Block, net.minecraft.block.BlockState> bsc) {
     	Map<String, List<String>> renderProperties = new HashMap<String, List<String>>();
 		// Build table of render properties and valid values

--- a/src/main/java/org/dynmap/blockscan/statehandlers/ForgeStateContainer.java
+++ b/src/main/java/org/dynmap/blockscan/statehandlers/ForgeStateContainer.java
@@ -18,7 +18,6 @@ import net.minecraft.block.GrassBlock;
 import net.minecraft.block.LeavesBlock;
 import net.minecraft.block.TallGrassBlock;
 import net.minecraft.block.VineBlock;
-import net.minecraft.state.IProperty;
 import net.minecraft.util.IStringSerializable;
 
 public class ForgeStateContainer extends StateContainer {
@@ -39,12 +38,13 @@ public class ForgeStateContainer extends StateContainer {
 			}
 			this.renderProperties.put(pn, propMap.get(pn));
 		}
-		
+
 		this.defStateIndex = 0;
 		int idx = 0;
 		for (BlockState bs : bsl) {
 			ImmutableMap.Builder<String,String> bld = ImmutableMap.builder();
-			for (IProperty<?> ent : bs.getProperties()) {
+			// func_235904_r_ == getProperties
+			for (net.minecraft.state.Property<?> ent : bs.func_235904_r_()) {
 				String pn = ent.getName();
 				if (renderprops.contains(pn)) {	// If valid render property
 					Comparable<?> v = bs.get(ent);

--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -1,6 +1,7 @@
 modLoader="javafml"
-loaderVersion="[31,)"
+loaderVersion="[35,)"
 issueTrackerURL="https://github.com/webbukkit/dynmap/issues"
+license="Apache Public License v2"
 [[mods]]
 modId="dynmapblockscan"
 version="${version}"
@@ -13,13 +14,13 @@ Generate block render definitions for Dynmap
 [[dependencies.dynmap]]
     modId="forge"
     mandatory=true
-    versionRange="[31,)"
+    versionRange="[35,)"
     ordering="NONE"
     # Side this dependency is applied on - BOTH, CLIENT or SERVER
     side="SERVER"
 [[dependencies.dynmap]]
     modId="minecraft"
     mandatory=true
-    versionRange="[1.15.2]"
+    versionRange="[1.16.4]"
     ordering="NONE"
     side="SERVER"


### PR DESCRIPTION
I did the required changes to make DynmapBlockScan work with 1.16.4 (did not test with lower versions as Dynmap works on that version as well).
Changes were:
- Replacing of IProperty with Proprty
- Replacing function usage BlockState.getProperties with BlockState.func_235904_r_ (whoever thought, this was a propert function name)
- Set dependency versions for MC and forge
- Add same license to mods.toml which is in Dynmap
- Add mikeprimm repository to repositories because with only having it in buildscript, I couldn't compile

Notice: I had to set max-tick-time to -1 for it to work. But as the mod only needs to run once and can be removed from the server afterwards, this should be fine.